### PR TITLE
Use random temporary directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,19 @@ name: Run SLURM jobs
 on:
   push:
 jobs:
+  test-checkout:
+    name: Test checkout
+    runs-on: [slurm]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./
+        with:
+          commands: |
+            cat README.md
   test-default:
     name: Run with default settings
     runs-on: [slurm]
     steps:
-      - uses: actions/checkout@v4
       - uses: ./
         with:
           commands: |
@@ -16,7 +24,6 @@ jobs:
     name: Run on NVIDIA A4000
     runs-on: [slurm]
     steps:
-      - uses: actions/checkout@v4
       - uses: ./
         with:
           partition: defq
@@ -35,7 +42,6 @@ jobs:
           - {type: AD4000, partition: fatq, rocm: false}
           - {type: W7700, partition: defq, rocm: true}
     steps:
-      - uses: actions/checkout@v4
       - uses: ./
         with:
           partition: ${{ matrix.gpu.partition }}

--- a/action.yml
+++ b/action.yml
@@ -22,14 +22,17 @@ runs:
     - name: Execute with srun
       shell: bash
       run: |
-        # Create script in runner's home directory
-        SCRIPT_PATH="$HOME/github-action-${GITHUB_JOB}-${GITHUB_RUN_ID}.sh"
+        # Create temporary directory
+        TEMP_DIR=$(mktemp -d --tmpdir=$GITHUB_WORKSPACE)
+        ln -s $GITHUB_WORKSPACE/* $TEMP_DIR
 
-        # Generate the script with proper shebang and commands
+
+        # Generate run script
+        SCRIPT_PATH="$TEMP_DIR/run.sh"
         cat << 'EOF' > "$SCRIPT_PATH"
         #!/bin/bash
         set -x
-        cd "$GITHUB_WORKSPACE"
+        cd "$TEMP_DIR"
         {
         ${{ inputs.commands }}
         } 2>&1  # Combine stdout and stderr
@@ -39,6 +42,7 @@ runs:
 
         # Build srun command components
         SRUN_ARGS=(
+          --chdir="$TEMP_DIR"
           --job-name="github-actions-$GITHUB_RUN_ID"
           --ntasks=1
           --nodes=1
@@ -63,7 +67,7 @@ runs:
         EXIT_CODE=$?
 
         # Cleanup
-        rm -f "$SCRIPT_PATH"
+        rm -rf "$TEMP_DIR"
 
         if [ $EXIT_CODE -ne 0 ]; then
           echo "❌ SLURM job failed with exit code: $EXIT_CODE"


### PR DESCRIPTION
To avoid conflicts between jobs that use the same `workFolder` (as defined in `.runner`), this runner creates a unique temporary directory for each job and sets it as the SLURM job’s working directory. This prevents issues like multiple jobs writing to the same build directory. To ensure access to any pre-existing files, such as those retrieved via the `checkout` action, those files are symlinked into the temporary directory.