### PR TITLE
Fix the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
     name: Run with default settings
     runs-on: [slurm]
     steps:
+      - uses: actions/checkout@v4
       - uses: ./
         with:
           commands: |
@@ -24,6 +25,7 @@ jobs:
     name: Run on NVIDIA A4000
     runs-on: [slurm]
     steps:
+      - uses: actions/checkout@v4
       - uses: ./
         with:
           partition: defq
@@ -42,6 +44,7 @@ jobs:
           - {type: AD4000, partition: fatq, rocm: false}
           - {type: W7700, partition: defq, rocm: true}
     steps:
+      - uses: actions/checkout@v4
       - uses: ./
         with:
           partition: ${{ matrix.gpu.partition }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
     name: Run with default settings
     runs-on: [slurm]
     steps:
-      - uses: actions/checkout@v4
       - uses: ./
         with:
           commands: |
@@ -25,7 +24,6 @@ jobs:
     name: Run on NVIDIA A4000
     runs-on: [slurm]
     steps:
-      - uses: actions/checkout@v4
       - uses: ./
         with:
           partition: defq
@@ -44,7 +42,6 @@ jobs:
           - {type: AD4000, partition: fatq, rocm: false}
           - {type: W7700, partition: defq, rocm: true}
     steps:
-      - uses: actions/checkout@v4
       - uses: ./
         with:
           partition: ${{ matrix.gpu.partition }}

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,11 @@ runs:
       run: |
         # Create temporary directory
         TEMP_DIR=$(mktemp -d --tmpdir=$RUNNER_TEMP)
-        ln -s $RUNNER_TEMP/* $TEMP_DIR
+
+        # Link files from the checkout action (if any)
+        if [ -d $GITHUB_WORKSPACE ]; then
+            ln -s $GITHUB_WORKSPACE/* $TEMP_DIR
+        fi
 
         # Generate run script
         SCRIPT_PATH="$TEMP_DIR/run.sh"

--- a/action.yml
+++ b/action.yml
@@ -23,9 +23,8 @@ runs:
       shell: bash
       run: |
         # Create temporary directory
-        TEMP_DIR=$(mktemp -d --tmpdir=$GITHUB_WORKSPACE)
-        ln -s $GITHUB_WORKSPACE/* $TEMP_DIR
-
+        TEMP_DIR=$(mktemp -d --tmpdir=$RUNNER_TEMP)
+        ln -s $RUNNER_TEMP/* $TEMP_DIR
 
         # Generate run script
         SCRIPT_PATH="$TEMP_DIR/run.sh"


### PR DESCRIPTION
There was still an issue with the temporary directory, which only surfaced after the runner's work directory was cleaned manually. The checkout action puts the file in a specific path, not necessarily relative to the current working directory. This action is now updated to take this into account.