### PR TITLE
Fail upon first error in pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,8 +39,7 @@ jobs:
       matrix:
         gpu:
           - {type: A4000, partition: defq, rocm: false}
-          - {type: AD4000, partition: fatq, rocm: false}
-          - {type: W7700, partition: defq, rocm: true}
+          - {type: AD4000, partition: defq, rocm: false}
     steps:
       - uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
       - name: Checkout action
         uses: actions/checkout@v4
         with:
-          path: ${{ runner.temp }}
+          path: action-${{ github.run_id }}
       - name: Run SLURM job
-        uses: ${{ runner.temp }}
+        uses: ./action-${{ github.run_id }}
         with:
           commands: |
             cat README.md
@@ -22,9 +22,9 @@ jobs:
       - name: Checkout action
         uses: actions/checkout@v4
         with:
-          path: ${{ runner.temp }}
+          path: action-${{ github.run_id }}
       - name: Run SLURM job
-        uses: ${{ runner.temp }}
+        uses: ./action-${{ github.run_id }}
         with:
           commands: |
             echo "Hostname: $(hostname)"
@@ -36,9 +36,9 @@ jobs:
       - name: Checkout action
         uses: actions/checkout@v4
         with:
-          path: ${{ runner.temp }}
+          path: action-${{ github.run_id }}
       - name: Run SLURM job
-        uses: ${{ runner.temp }}
+        uses: ./action-${{ github.run_id }}
         with:
           partition: defq
           gres: gpu:A4000
@@ -58,9 +58,9 @@ jobs:
       - name: Checkout action
         uses: actions/checkout@v4
         with:
-          path: ${{ runner.temp }}/${{ strategy.job-index }}
+          path: action-${{ github.run_id }}-${{ strategy.job-index }}
       - name: Run SLURM job
-        uses: ${{ runner.temp }}/${{ strategy.job-index }}
+        uses: ./action-${{ github.run_id }}-${{ strategy.job-index }}
         with:
           partition: ${{ matrix.gpu.partition }}
           gres: gpu:${{ matrix.gpu.type }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,33 +2,12 @@ name: Run SLURM jobs
 on:
   push:
 jobs:
-  test-checkout:
-    name: Test checkout
-    runs-on: [slurm]
-    env:
-      ACTION_PATH: ./action-${{ github.run_id }}
-    steps:
-      - name: Checkout action
-        uses: actions/checkout@v4
-        with:
-          path: ${{ env.ACTION_PATH }}
-      - name: Run SLURM job
-        uses: ${{ env.ACTION_PATH }}
-        with:
-          commands: |
-            cat README.md
   test-default:
     name: Run with default settings
     runs-on: [slurm]
-    env:
-      ACTION_PATH: ./action-${{ github.run_id }}
     steps:
-      - name: Checkout action
-        uses: actions/checkout@v4
-        with:
-          path: ${{ env.ACTION_PATH }}
-      - name: Run SLURM job
-        uses: ${{ env.ACTION_PATH }}
+      - uses: actions/checkout@v4
+      - uses: ./
         with:
           commands: |
             echo "Hostname: $(hostname)"
@@ -36,15 +15,9 @@ jobs:
   test-a4000:
     name: Run on NVIDIA A4000
     runs-on: [slurm]
-    env:
-      ACTION_PATH: ./action-${{ github.run_id }}
     steps:
-      - name: Checkout action
-        uses: actions/checkout@v4
-        with:
-          path: ${{ env.ACTION_PATH }}
-      - name: Run SLURM job
-        uses: ${{ env.ACTION_PATH }}
+      - uses: actions/checkout@v4
+      - uses: ./
         with:
           partition: defq
           gres: gpu:A4000
@@ -58,26 +31,15 @@ jobs:
     strategy:
       matrix:
         gpu:
-          - {type: A4000, partition: defq, rocm: false}
-          - {type: AD4000, partition: defq, rocm: false}
-    env:
-      ACTION_PATH: ./action-${{ github.run_id }}-${{ strategy.job-index }}
+          - {type: A4000, partition: defq}
+          - {type: AD4000, partition: defq}
     steps:
-      - name: Checkout action
-        uses: actions/checkout@v4
-        with:
-          path: ${{ env.ACTION_PATH }}
-      - name: Run SLURM job
-        uses: ${{ env.ACTION_PATH }}
+      - uses: actions/checkout@v4
+      - uses: ./
         with:
           partition: ${{ matrix.gpu.partition }}
           gres: gpu:${{ matrix.gpu.type }}
           time: 00:01:00
-          commands: |-
-            if ${{ matrix.gpu.rocm }}; then
-              echo "=== ROCM-SMI ==="
-              /opt/rocm/bin/amd-smi
-            else
-              echo "=== NVIDIA-SMI ==="
-              nvidia-smi
-            fi
+          commands: |
+            echo "Hostname: $(hostname)"
+            nvidia-smi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,8 @@
 name: Run SLURM jobs
 on:
   push:
-
 env:
   ACTION_REF: ${{ github.repository }}@${{ github.sha }}
-
 jobs:
   test-checkout:
     name: Test checkout
@@ -15,7 +13,6 @@ jobs:
         with:
           commands: |
             cat README.md
-
   test-default:
     name: Run with default settings
     runs-on: [slurm]
@@ -25,7 +22,6 @@ jobs:
           commands: |
             echo "Hostname: $(hostname)"
             nvidia-smi || true
-
   test-a4000:
     name: Run on NVIDIA A4000
     runs-on: [slurm]
@@ -38,7 +34,6 @@ jobs:
           commands: |
             echo "Hostname: $(hostname)"
             nvidia-smi
-
   test-gpus:
     name: Run on various GPUs
     runs-on: [slurm]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,26 +5,30 @@ jobs:
   test-checkout:
     name: Test checkout
     runs-on: [slurm]
+    env:
+      ACTION_PATH: ./action-${{ github.run_id }}
     steps:
       - name: Checkout action
         uses: actions/checkout@v4
         with:
-          path: action-${{ github.run_id }}
+          path: ${{ env.ACTION_PATH }}
       - name: Run SLURM job
-        uses: ./action-${{ github.run_id }}
+        uses: ${{ env.ACTION_PATH }}
         with:
           commands: |
             cat README.md
   test-default:
     name: Run with default settings
     runs-on: [slurm]
+    env:
+      ACTION_PATH: ./action-${{ github.run_id }}
     steps:
       - name: Checkout action
         uses: actions/checkout@v4
         with:
-          path: action-${{ github.run_id }}
+          path: ${{ env.ACTION_PATH }}
       - name: Run SLURM job
-        uses: ./action-${{ github.run_id }}
+        uses: ${{ env.ACTION_PATH }}
         with:
           commands: |
             echo "Hostname: $(hostname)"
@@ -32,13 +36,15 @@ jobs:
   test-a4000:
     name: Run on NVIDIA A4000
     runs-on: [slurm]
+    env:
+      ACTION_PATH: ./action-${{ github.run_id }}
     steps:
       - name: Checkout action
         uses: actions/checkout@v4
         with:
-          path: action-${{ github.run_id }}
+          path: ${{ env.ACTION_PATH }}
       - name: Run SLURM job
-        uses: ./action-${{ github.run_id }}
+        uses: ${{ env.ACTION_PATH }}
         with:
           partition: defq
           gres: gpu:A4000
@@ -54,13 +60,15 @@ jobs:
         gpu:
           - {type: A4000, partition: defq, rocm: false}
           - {type: AD4000, partition: defq, rocm: false}
+    env:
+      ACTION_PATH: ./action-${{ github.run_id }}-${{ strategy.job-index }}
     steps:
       - name: Checkout action
         uses: actions/checkout@v4
         with:
-          path: action-${{ github.run_id }}-${{ strategy.job-index }}
+          path: ${{ env.ACTION_PATH }}
       - name: Run SLURM job
-        uses: ./action-${{ github.run_id }}-${{ strategy.job-index }}
+        uses: ${{ env.ACTION_PATH }}
         with:
           partition: ${{ matrix.gpu.partition }}
           gres: gpu:${{ matrix.gpu.type }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         gpu:
           - {type: A4000, partition: defq}
-          - {type: AD4000, partition: defq}
+          - {type: AD4000, partition: rbq}
     steps:
       - uses: actions/checkout@v4
       - uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,17 @@
 name: Run SLURM jobs
 on:
   push:
-env:
-  ACTION_REF: ${{ github.repository }}@${{ github.sha }}
 jobs:
   test-checkout:
     name: Test checkout
     runs-on: [slurm]
     steps:
-      - uses: actions/checkout@v4
-      - uses: ${{ env.ACTION_REF }}
+      - name: Checkout action
+        uses: actions/checkout@v4
+        with:
+          path: ${{ runner.temp }}
+      - name: Run SLURM job
+        uses: ${{ runner.temp }}
         with:
           commands: |
             cat README.md
@@ -17,7 +19,12 @@ jobs:
     name: Run with default settings
     runs-on: [slurm]
     steps:
-      - uses: ${{ env.ACTION_REF }}
+      - name: Checkout action
+        uses: actions/checkout@v4
+        with:
+          path: ${{ runner.temp }}
+      - name: Run SLURM job
+        uses: ${{ runner.temp }}
         with:
           commands: |
             echo "Hostname: $(hostname)"
@@ -26,7 +33,12 @@ jobs:
     name: Run on NVIDIA A4000
     runs-on: [slurm]
     steps:
-      - uses: ${{ env.ACTION_REF }}
+      - name: Checkout action
+        uses: actions/checkout@v4
+        with:
+          path: ${{ runner.temp }}
+      - name: Run SLURM job
+        uses: ${{ runner.temp }}
         with:
           partition: defq
           gres: gpu:A4000
@@ -43,7 +55,12 @@ jobs:
           - {type: A4000, partition: defq, rocm: false}
           - {type: AD4000, partition: defq, rocm: false}
     steps:
-      - uses: ${{ env.ACTION_REF }}
+      - name: Checkout action
+        uses: actions/checkout@v4
+        with:
+          path: ${{ runner.temp }}/${{ strategy.job-index }}
+      - name: Run SLURM job
+        uses: ${{ runner.temp }}/${{ strategy.job-index }}
         with:
           partition: ${{ matrix.gpu.partition }}
           gres: gpu:${{ matrix.gpu.type }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,30 +1,36 @@
 name: Run SLURM jobs
 on:
   push:
+
+env:
+  ACTION_REF: ${{ github.repository }}@${{ github.sha }}
+
 jobs:
   test-checkout:
     name: Test checkout
     runs-on: [slurm]
     steps:
       - uses: actions/checkout@v4
-      - uses: ./
+      - uses: ${{ env.ACTION_REF }}
         with:
           commands: |
             cat README.md
+
   test-default:
     name: Run with default settings
     runs-on: [slurm]
     steps:
-      - uses: ./
+      - uses: ${{ env.ACTION_REF }}
         with:
           commands: |
             echo "Hostname: $(hostname)"
             nvidia-smi || true
+
   test-a4000:
     name: Run on NVIDIA A4000
     runs-on: [slurm]
     steps:
-      - uses: ./
+      - uses: ${{ env.ACTION_REF }}
         with:
           partition: defq
           gres: gpu:A4000
@@ -32,6 +38,7 @@ jobs:
           commands: |
             echo "Hostname: $(hostname)"
             nvidia-smi
+
   test-gpus:
     name: Run on various GPUs
     runs-on: [slurm]
@@ -41,7 +48,7 @@ jobs:
           - {type: A4000, partition: defq, rocm: false}
           - {type: AD4000, partition: defq, rocm: false}
     steps:
-      - uses: ./
+      - uses: ${{ env.ACTION_REF }}
         with:
           partition: ${{ matrix.gpu.partition }}
           gres: gpu:${{ matrix.gpu.type }}

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
         SCRIPT_PATH="$(mktemp -p ${RUNNER_TEMP})"
         cat << 'EOF' > "$SCRIPT_PATH"
         #!/bin/bash
-        set -x
+        set -euo pipefail
         {
         ${{ inputs.commands }}
         } 2>&1  # Combine stdout and stderr


### PR DESCRIPTION
Make sure the script fails upon the first error. This prevents transient failures and confusing CI logs.

Some other changes were needed to make the CI pass again using the new runners:

- Make sure to checkout for every step (fixes missing files)
- Update for new GRES settings